### PR TITLE
adds cifs support for accessing shared data

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -3,6 +3,8 @@ From: continuumio/anaconda3
 
 %runscript
 
+     echo "Mounting shared drive..."
+     /sbin/mount.cifs //server/share /opt/notebooks/s -o user=shareusername,password=sharepassword
      echo "Starting notebook..."
      echo "Open browser to localhost:8888"
      exec /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=8888 --no-browser --allow-root
@@ -12,5 +14,10 @@ From: continuumio/anaconda3
      # Install jupyter notebook
      /opt/conda/bin/conda install jupyter -y --quiet 
      mkdir /opt/notebooks
+     # Make a mountpoint that will be visible within jupyter
+     mkdir /opt/notebooks/s
+     # Install utils to allow connections to share
+     apt-get install cifs-utils libtalloc2 libwbclient0 -y
      apt-get autoremove -y
      apt-get clean
+


### PR DESCRIPTION
This branch shows how to make a mount point /opt/notebooks/s visible within jupyter with a connection to a cifs server \server\share with example username / password shareusername/sharepassword

I have been using this, basically good for accessing data (or even notebooks) on a "windows share" someplace else.

You'll probably want to make your own private branch of this, if you use
it, and change the credentials or use a credentials file you don't
commit.