### PR TITLE
windows fileshare support from within jupyter

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,17 @@ and here I am sitting in my local directory, but the entire software and depdenc
 If you are running Singularity in Windows through vagrant. You will need to configure port fowarding in the Vagrantfile that you use to set up the Singularity container as well. 
 As an example, you should add a line that might look like this.
 `config.vm.network "forwarded_port", guest: 8888, host: 8888, host_ip: "127.0.0.1"`
+
+This `cifs` branch has support for mounting a 'windows' fileshare from within the container, so that you can work with such shared files from within jupyter as if they are within the image.
+
+You'll want to edit the Singularity file to change the file server's name and share name, as well as the credentials for logging into it.
+It's not a bad idea to make a new git branch to keep those changes in, too:
+
+```bash
+git checkout -b private
+git add Singularity
+git commit -m 'never merge -- contains share credentials'
+```
+
+You can later do `git pull --rebase origin cifs` if you want to keep things updated without losing your private changes. 
+Be aware that to get new features, you may need to delete and rebuild your singularity image -- so backup your work outside of the image first.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ $ sudo singularity build --sandbox jupyter-box Singularity
 ```
 
 Then to run our container, since we need to write files to `/opt/notebooks` inside the container, we must use sudo and add the `--writable` command:
+This `cifs` branch has support for mounting a 'windows' fileshare from within the container, so that you can work with such shared files from within jupyter as if they are within the image.
+You will need to replace `server sharename shareuser sharepassword` with your own details so that `//server/sharename` will turn up as `./share` in jupyter.
 
 ```bash
-$ sudo singularity run --writable jupyter-box
+$ sudo singularity run --writable jupyter-box server sharename shareuser sharepassword
 ```
 
 When we open the browser, we see our server! Cool!
@@ -61,17 +63,3 @@ and here I am sitting in my local directory, but the entire software and depdenc
 If you are running Singularity in Windows through vagrant. You will need to configure port fowarding in the Vagrantfile that you use to set up the Singularity container as well. 
 As an example, you should add a line that might look like this.
 `config.vm.network "forwarded_port", guest: 8888, host: 8888, host_ip: "127.0.0.1"`
-
-This `cifs` branch has support for mounting a 'windows' fileshare from within the container, so that you can work with such shared files from within jupyter as if they are within the image.
-
-You'll want to edit the Singularity file to change the file server's name and share name, as well as the credentials for logging into it.
-It's not a bad idea to make a new git branch to keep those changes in, too:
-
-```bash
-git checkout -b private
-git add Singularity
-git commit -m 'never merge -- contains share credentials'
-```
-
-You can later do `git pull --rebase origin cifs` if you want to keep things updated without losing your private changes. 
-Be aware that to get new features, you may need to delete and rebuild your singularity image -- so backup your work outside of the image first.

--- a/Singularity
+++ b/Singularity
@@ -3,8 +3,12 @@ From: continuumio/anaconda3
 
 %runscript
 
-     echo "Mounting shared drive..."
-     /sbin/mount.cifs //server/share /opt/notebooks/share -o user=shareusername,password=sharepassword
+     server="${1}"
+     share="${2}"
+     shareuser="${3}"
+     sharepw="${4}"
+     echo "Mounting shared drive //${server}/${share} with username ${shareuser}"
+     /sbin/mount.cifs //${server}/${share} /opt/notebooks/share -o user=${shareuser},password=${sharepw}
      echo "Starting notebook..."
      echo "Open browser to localhost:8888"
      exec /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=8888 --no-browser --allow-root

--- a/Singularity
+++ b/Singularity
@@ -3,6 +3,8 @@ From: continuumio/anaconda3
 
 %runscript
 
+     echo "Mounting shared drive..."
+     /sbin/mount.cifs //server/share /opt/notebooks/s -o user=shareusername,password=sharepassword
      echo "Starting notebook..."
      echo "Open browser to localhost:8888"
      exec /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=8888 --no-browser --allow-root
@@ -12,5 +14,10 @@ From: continuumio/anaconda3
      # Install jupyter notebook
      /opt/conda/bin/conda install jupyter -y --quiet 
      mkdir /opt/notebooks
+     # Make a mountpoint that will be visible within jupyter
+     mkdir /opt/notebooks/s
+     # Install utils to allow connections to share
+     apt-get install cifs-utils libtalloc2 libwbclient0 -y
      apt-get autoremove -y
      apt-get clean
+

--- a/Singularity
+++ b/Singularity
@@ -4,7 +4,7 @@ From: continuumio/anaconda3
 %runscript
 
      echo "Mounting shared drive..."
-     /sbin/mount.cifs //server/share /opt/notebooks/s -o user=shareusername,password=sharepassword
+     /sbin/mount.cifs //server/share /opt/notebooks/share -o user=shareusername,password=sharepassword
      echo "Starting notebook..."
      echo "Open browser to localhost:8888"
      exec /opt/conda/bin/jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=8888 --no-browser --allow-root
@@ -15,7 +15,7 @@ From: continuumio/anaconda3
      /opt/conda/bin/conda install jupyter -y --quiet 
      mkdir /opt/notebooks
      # Make a mountpoint that will be visible within jupyter
-     mkdir /opt/notebooks/s
+     mkdir /opt/notebooks/share
      # Install utils to allow connections to share
      apt-get install cifs-utils libtalloc2 libwbclient0 -y
      apt-get autoremove -y


### PR DESCRIPTION
This will remain in the 'cifs' fork so as not to clutter `master`, and because it's not everyone's cup of tea.

I've added some guidance to the readme to make it less scary for newcomers to use.